### PR TITLE
Remove type constraint for breakpoint-to-event.

### DIFF
--- a/lib/MoarVM/Remote.rakumod
+++ b/lib/MoarVM/Remote.rakumod
@@ -116,7 +116,7 @@ class MoarVM::Remote {
 
     has %!event-suppliers;
 
-    has %!breakpoint-to-event{Any};
+    has %!breakpoint-to-event;
 
     has Lock $!id-lock .= new;
     has int32 $!req_id = 1;


### PR DESCRIPTION
Type constraint prevented clearing breakpoints (because of object equality? I dunno) -- a "Use of uninitialized value of type Any in string context." exception was thrown.